### PR TITLE
Add an error matcher to `graphQLError`, and `graphQLSubset`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ npm install --save-dev chai-graphql
 ```
 
 ## API
-- `assert.graphQl(response, [expectedData])` performs a deep equals on the `response.data` and expectedData if present. Throws if there are any errors in `response.errors`. Returns `respose.data`
-- `assert.graphQLError(response)` throws if there are not any `response.errors`, returns the `response.errors`
+- `assert.graphQl(response, [expectedData])` performs a deep equals on the `response.data` and expectedData if present. Throws if there are any errors in `response.errors`. Returns `response.data`
+- `assert.graphQLSubset(response, [subsetOfExpectedData])` performs a subset match of `response.data` and expectedData if present. Throws if there are any errors in `response.errors`. Returns `response.data`
+- `assert.graphQLError(response, [errorMatcher])` throws if there are not any `response.errors`, returns the `response.errors`. `errorMatcher` can be a string, regex or an array of strings or regexes. In the string or regex form the error's message property will be [`match()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match) by the `errorMatcher`. In the array form, each `errorMatcher` is tested against each error in order. If there a greater or fewer number of matchers than errors an it will throw.
 
 ## Usage
 In your setup
@@ -32,11 +33,16 @@ var goodResponse = {
 
 // Passes
 assert.graphQL(goodResponse, { foo: 'bar' })
+assert.graphQLSubset(goodResponse, { foo: 'bar' })
 assert.graphQL(goodResponse)
+assert.graphQLSubset(goodResponse)
+assert.graphQLSubset(goodResponse, { })
 assert.notGraphQLError(goodResponse)
 expect(goodResponse).to.be.graphQl({ foo: 'bar' })
 
 // Fails
+assert.graphQL(goodResponse, { foo: 'FAIL' })
+assert.graphQL(goodResponse, { })
 assert.graphQLError(goodResponse)
 expect(goodResponse).to.be.graphQLError()
 
@@ -55,9 +61,18 @@ const badResponse = {
 assert.graphQLError(badResponse)
 expect(badResponse).to.be.graphQLError()
 
+assert.graphQLError(badResponse, 'Error message')
+assert.graphQLError(badResponse, /GraphQL Error Object/)
+assert.graphQLError(badResponse, [
+  'Error message',
+  /GraphQL Error Object/
+])
+
 // fails
 assert.graphQL(badResponse, { foo: 'bar' })
 assert.graphQL(badResponse)
 assert.notGraphQLError(badResponse)
 expect(badResponse).to.be.graphQl({ foo: 'bar' })
+assert.graphQLError(badResponse, 'Rando Error')
+assert.graphQLError(badResponse, [ 'Error message' ])
 ```

--- a/lib/chai-graphql.js
+++ b/lib/chai-graphql.js
@@ -1,24 +1,30 @@
+const util = require('util')
+
 module.exports = function chaiGraphQL (chai, utils) {
   const Assertion = chai.Assertion
+  const showDiff = chai.config.showDiff
 
   Assertion.addMethod('graphQL', function (expected) {
     const errors = this._obj.errors
     if (errors) {
       this.assert(
         errors === undefined,
-        `expected "response.errors" to be undefined but got:\n${printErrors(errors)}`,
-        `expected "response.errors" to not be undefined`
+        `Expected "response.errors" to be "undefined" but got #{act}`,
+        `Expected "response.errors" to not be #{exp} but got "undefined"`,
+        [],
+        errors,
+        showDiff
       )
       return
     }
 
     const data = this._obj.data
     if (data === null) {
-      throw new Error(`expected "response.data" to be an object found "null"`)
+      throw new Error(`Expected "response.data" to be an object found "null"`)
     }
 
     if (typeof data !== 'object') {
-      throw new Error(`expected "response.data" to be an object found "${typeof data}"`)
+      throw new Error(`Expected "response.data" to be an object found "${typeof data}"`)
     }
 
     if (expected !== undefined) {
@@ -28,13 +34,64 @@ module.exports = function chaiGraphQL (chai, utils) {
     return data
   })
 
+  Assertion.addMethod('graphQLSubset', function (expected) {
+    const errors = this._obj.errors
+    if (errors) {
+      this.assert(
+        errors === undefined,
+        `Expected "response.errors" to be "undefined" but got #{act}`,
+        `Expected "response.errors" to not be #{exp} but got "undefined"`,
+        [],
+        errors,
+        showDiff
+      )
+      return
+    }
+
+    const data = this._obj.data
+    if (data === null) {
+      throw new Error(`Expected "response.data" to be an object found "null"`)
+    }
+
+    if (typeof data !== 'object') {
+      throw new Error(`Expected "response.data" to be an object found "${typeof data}"`)
+    }
+
+    if (expected === undefined) {
+      return data
+    }
+
+    this.assert(
+      compareSubset(expected, data),
+      'expected #{act} to contain subset #{exp}',
+      'expected #{act} to not contain subset #{exp}',
+      expected,
+      data,
+      showDiff
+    )
+    return data
+  })
+
   Assertion.addMethod('graphQLError', function (expected) {
     const errors = this._obj.errors
-    this.assert(
-      Array.isArray(errors),
-      `expected "response.errors" to be an array`,
-      `expected "response.errors" to not be an array`
-    )
+    chai.assert.isArray(errors, '"response.errors" has no errors')
+    this.assert(errors.length > 0, `Expected there to be at least one error instead received an empty array.`)
+
+    if (Array.isArray(expected)) {
+      if (errors.length !== expected.length) {
+        throw new Error(`Received a ${errors.length} errors and you're trying to match ${expected.length} errors.\n ${printObject(errors)}`)
+      }
+      expected.forEach((matcher, index) => {
+        const error = errors[index]
+        if (!matchError(error, matcher)) {
+          throw new Error(`Expected ${printObject(matcher)} to match ${printObject(error)}\n ${printObject(errors)}`)
+        }
+      })
+    } else if (expected !== undefined) {
+      if (!detectMatchingError(errors, expected)) {
+        throw new Error(`Expected ${printObject(expected)} to match at least one error`)
+      }
+    }
     return errors
   })
 
@@ -42,37 +99,76 @@ module.exports = function chaiGraphQL (chai, utils) {
     return new chai.Assertion(val, msg).graphQL(exp)
   }
 
+  chai.assert.graphQLSubset = (val, exp, msg) => {
+    return new chai.Assertion(val, msg).graphQLSubset(exp)
+  }
+
   chai.assert.graphQLError = (val, exp, msg) => {
     return new chai.Assertion(val, msg).graphQLError(exp)
   }
-
   chai.assert.graphQLErrors = chai.assert.graphQLError
 
   chai.assert.notGraphQLError = (val, exp, msg) => {
     return new chai.Assertion(val, msg).graphQL(exp)
   }
-
   chai.assert.notGraphQLErrors = chai.assert.notGraphQLError
 }
 
-function printErrors (errors) {
-  (errors || []).forEach(error => {
-    if (error instanceof Error) {
-      if (typeof error.stack === 'string') {
-        error.stack = error.stack.split('\n').map(line => line.trim())
-      }
+function printObject (errors) {
+  return util.inspect(errors, { showHidden: true, showProxy: true })
+}
 
-      Object.defineProperties(error, {
-        message: {
-          enumerable: true,
-          value: error.message
-        },
-        stack: {
-          enumerable: true,
-          value: error.stack
-        }
-      })
+function matchError (error, matcher) {
+  if (!error || !error.message || typeof error.message !== 'string') {
+    throw new Error(`Detected an Error with no string message`)
+  }
+  return error.message.match(matcher)
+}
+
+function detectMatchingError (errors, matcher) {
+  return errors.find(err => matchError(err, matcher)) !== undefined
+}
+
+function compareSubset (expected, actual) {
+  if (expected === actual) {
+    return true
+  }
+  if (typeof actual !== typeof expected) {
+    return false
+  }
+  if (typeof expected !== 'object' || expected === null) {
+    return expected === actual
+  }
+  if (!!expected && !actual) {
+    return false
+  }
+
+  if (Array.isArray(expected)) {
+    if (typeof actual.length !== 'number') {
+      return false
     }
+    var aa = Array.prototype.slice.call(actual)
+    return expected.every(function (exp) {
+      return aa.some(function (act) {
+        return compareSubset(exp, act)
+      })
+    })
+  }
+
+  if (expected instanceof Date) {
+    if (actual instanceof Date) {
+      return expected.getTime() === actual.getTime()
+    } else {
+      return false
+    }
+  }
+
+  return Object.keys(expected).every(function (key) {
+    var eo = expected[key]
+    var ao = actual[key]
+    if (typeof eo === 'object' && eo !== null && ao !== null) {
+      return compareSubset(eo, ao)
+    }
+    return ao === eo
   })
-  return JSON.stringify(errors, null, 2)
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/chai-graphql.js",
   "scripts": {
     "test": "mocha",
-    "lint": "eslint"
+    "lint": "eslint **/*.js"
   },
   "repository": {
     "type": "git",

--- a/test/chai-graphql.js
+++ b/test/chai-graphql.js
@@ -1,7 +1,14 @@
 const response = Object.freeze({
-  data: {
+  data: Object.freeze({
     foo: 'bar'
-  }
+  })
+})
+
+const bigResponse = Object.freeze({
+  data: Object.freeze({
+    foo: 'bar',
+    bar: Object.freeze([ 'zap' ])
+  })
 })
 
 const badResponse = Object.freeze({
@@ -20,7 +27,7 @@ describe('graphQL', () => {
   })
 
   it('returns the data', () => {
-    assert.deepEqual(assert.graphQL(response), { foo: 'bar' })
+    assert.deepEqual(assert.graphQL(response), response.data)
   })
 
   it(`fails if the data doesn't match`, () => {
@@ -59,14 +66,101 @@ describe('notGraphQLError', () => {
   })
 })
 
+describe('graphQLSubset', () => {
+  it('matches the data', () => {
+    assert.graphQLSubset(bigResponse, bigResponse.data)
+  })
+
+  it('matches a subset of the data', () => {
+    assert.graphQLSubset(bigResponse, { foo: 'bar' })
+  })
+
+  it('returns the data', () => {
+    assert.deepEqual(assert.graphQLSubset(bigResponse), bigResponse.data)
+  })
+
+  it(`fails if the data doesn't match`, () => {
+    assert.throws(() => assert.graphQLSubset(response, { sonic: 'boom' }))
+  })
+
+  it('fails if there are errors', () => {
+    assert.throws(() => assert.graphQLSubset(badResponse, { foo: 'bar' }))
+  })
+
+  it('allows no matched data', () => {
+    assert.graphQLSubset(response)
+  })
+
+  it('fails if there is an error an no matched data', () => {
+    assert.throws(() => assert.graphQLSubset(badResponse))
+  })
+
+  it('fails if there is no data', () => {
+    assert.throws(() => assert.graphQLSubset({}))
+  })
+
+  it('fails if there is null data', () => {
+    assert.throws(() => assert.graphQLSubset({ data: null }))
+  })
+})
+
+describe('notGraphQLError', () => {
+  it('passes if there are no errors', () => {
+    assert.notGraphQLError(response)
+  })
+
+  it('fails if there are errors', () => {
+    assert.throws(() => assert.notGraphQLError(badResponse))
+  })
+})
+
 describe('graphQLError', () => {
   it('matches on errors', () => {
     assert.graphQLError(badResponse)
   })
+
   it('fails with no errors', () => {
     assert.throws(() => assert.graphQLError(response))
   })
+
   it('returns the errors', () => {
     assert.deepEqual(assert.graphQLError(badResponse), badResponse.errors)
+  })
+
+  it('matches any errors against a string message', () => {
+    assert.graphQLError(badResponse, 'Error message')
+    assert.graphQLError(badResponse, 'Regular Error')
+  })
+
+  it('matches any errors against a regex message', () => {
+    assert.graphQLError(badResponse, /message/)
+    assert.graphQLError(badResponse, /Regular/)
+  })
+
+  it('matches an array of errors in order', () => {
+    assert.graphQLError(badResponse, [
+      'Error message',
+      /Regular/
+    ])
+  })
+
+  it('fails if no matching error', () => {
+    assert.throws(() => assert.graphQLError(badResponse, 'garbage'))
+    assert.throws(() => assert.graphQLError(badResponse, /garbage/))
+  })
+
+  it('fails if there was an unexpected number of errors', () => {
+    assert.throws(() => assert.graphQLError(badResponse, [
+      /message/
+    ]))
+  })
+
+  it('fails if an array of messages are out of order', () => {
+    assert.throws(() => {
+      assert.graphQLError(badResponse, [
+        /Regular/,
+        'Error message'
+      ])
+    })
   })
 })


### PR DESCRIPTION
Should also improve output of assertion errors.

closes #1 
closes #3